### PR TITLE
Woocom 3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 custom-related-products-woocommerce
 ===================================
 
-Custom Related Products for WooCommerce lets you choose which products should show in the related products area on a product detail page instead of simply showing products from the same category. This plugin has been tested with WooCommerce 2.1+.
+Custom Related Products for WooCommerce lets you choose which products should show in the related products area on a product detail page instead of simply showing products from the same category. This plugin has been tested with WooCommerce from version 2.1 to 3.0.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: scottnelle
 Tags: woocommerce, related products
 Requires at least: 3.0
-Tested up to: 4.5
-Stable tag: 1.2
+Tested up to: 4.7
+Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,7 +20,7 @@ How to use:
 * As long as your theme has a related products section, you're done! By default all WooCommerce themes have this, so unless your theme specifically disables it you're all set.
 * If you don't select related products for any product, it will fall back to the WooCommerce default behavior of selecting random products by category. If you'd prefer to show no products you can configure that under WooCommerce > Custom Related Products.
 
-This plugin has been tested with WooCommerce 2.1 through 2.6.
+This plugin has been tested with WooCommerce 2.1 through 3.0.
 
 == Installation ==
 
@@ -29,6 +29,9 @@ This plugin has been tested with WooCommerce 2.1 through 2.6.
 1. Configure under WooCommerce > Custom Related Products
 
 == Changelog ==
+= 1.3 =
+* Update to work with the UI rewrite and related post querying rewrite in WooCommerce 3.0.
+
 = 1.2 =
 * Fix an error triggered in admin when a related product couldn't be found because it was deleted.
 

--- a/woocommerce-custom-related-products.php
+++ b/woocommerce-custom-related-products.php
@@ -19,7 +19,8 @@ Author URI:  http://scottnelle.com
  * @return bool Modified value - should we force related products to display?
  */
 function crp_force_display( $result, $product_id ) {
-	return empty( get_post_meta( $product_id, '_related_ids', true ) ) ? $result : true;
+	$related_ids = get_post_meta( $product_id, '_related_ids', true );
+	return empty( $related_ids ) ? $result : true;
 }
 add_filter( 'woocommerce_product_related_posts_force_display', 'crp_force_display', 10, 2 );
 


### PR DESCRIPTION
Updates the plugin to work with WooCommerce 3.0 While preserving backward compatibility. Check diffs for individual commits or append `w=1` to ignore whitespace changes, as the final commit replaces windows line endings with Unix line endings, making it appear as if every line has changed.

This pull request addresses issue #8 and increments the plugin version to 1.3.